### PR TITLE
fix: route.allowedMethods registration failed

### DIFF
--- a/templates2/js/app.js
+++ b/templates2/js/app.js
@@ -33,8 +33,8 @@ app.use(async (ctx, next) => {
 })
 
 // routes
-app.use(index.routes(), index.allowedMethods())
-app.use(users.routes(), users.allowedMethods())
+app.use(index.routes()).use(index.allowedMethods())
+app.use(users.routes()).use(users.allowedMethods())
 
 // error-handling
 app.on('error', (err, ctx) => {


### PR DESCRIPTION
`app.use(index.routes(), index.allowedMethods())`这样写法route.allowedMethods()应该没有注册到koa2 中间件里面去，我本地跑demo调试, 执行option也不会进去断点。 需要改成 app.use(index.routes()).use(index.allowedMethods()) 即可。没明白之前写法的作用是什么,请指教。